### PR TITLE
Resolve issues opening passive data connection  with a non-local IP NATed

### DIFF
--- a/src/main/java/org/waarp/ftp/core/command/parameter/PASV.java
+++ b/src/main/java/org/waarp/ftp/core/command/parameter/PASV.java
@@ -87,8 +87,15 @@ public class PASV extends AbstractCommand {
 		}
 		// Return the address in Ftp format
 		InetSocketAddress local = getSession().getDataConn().getLocalAddress();
+		int servPort = local.getPort();
+
+		String address = getSession().getConfiguration().getServerAddress();
+		if (address == null) {
+			address = local.getAddress().getHostAddress();
+		}
+
 		String slocal = "Entering Passive Mode (" +
-				FtpChannelUtils.getAddress(local) + ")";
+				FtpChannelUtils.getAddress(address, servPort) + ")";
 		InetAddress remote = getSession().getDataConn().getRemoteAddress()
 				.getAddress();
 		// Add the current FtpSession into the reference of session since the

--- a/src/main/java/org/waarp/ftp/core/data/FtpDataAsyncConn.java
+++ b/src/main/java/org/waarp/ftp/core/data/FtpDataAsyncConn.java
@@ -211,13 +211,8 @@ public class FtpDataAsyncConn {
 	 */
 	public void setPassive() {
 		unbindPassive();
-		String address = session.getConfiguration().getServerAddress();
-		if (address == null) {
-			localAddress = new InetSocketAddress(FtpChannelUtils
-					.getLocalInetAddress(session.getControlChannel()), localPort);
-		} else {
-			localAddress = new InetSocketAddress(address, localPort);
-		}
+		localAddress = new InetSocketAddress(FtpChannelUtils
+				.getLocalInetAddress(session.getControlChannel()), localPort);
 		passiveMode = true;
 		isBind = false;
 	}

--- a/src/main/java/org/waarp/ftp/core/utils/FtpChannelUtils.java
+++ b/src/main/java/org/waarp/ftp/core/utils/FtpChannelUtils.java
@@ -147,6 +147,18 @@ public class FtpChannelUtils implements Runnable {
 	}
 
 	/**
+	 * Return the Address in the format compatible with FTP argument
+	 *
+	 * @param address
+	 * @param port
+	 * @return the String representation of the address
+	 */
+	public static String getAddress(String address, int port) {
+		return address.replace('.', ',') + ',' +
+				(port >> 8) + ',' + (port & 0xFF);
+	}
+
+	/**
 	 * Get the (RFC2428) InetSocketAddress corresponding to the FTP format of address (RFC2428)
 	 * 
 	 * @param arg


### PR DESCRIPTION
When Waarp Gateway FTP is behind a natted IP, the <serveraddr> tag in the config file
is used to configure the externally visible IP.
However, if serveraddr is given, Waarp Gateway FTP tries to open a socket on this specific
address to receive a passive connection.
When the natted IP given in serveraddr is not local, the socket cannot be opened.

This fix does the following :
- The passive socket is always opened on the same IP as the authentication socket
- The IP address given in serveraddr is only considered when generating the reply
  to the PASV command
