### PR TITLE
Allow the FEAT command before USER

### DIFF
--- a/src/main/java/org/waarp/ftp/core/command/FtpCommandCode.java
+++ b/src/main/java/org/waarp/ftp/core/command/FtpCommandCode.java
@@ -49,7 +49,7 @@ public enum FtpCommandCode {
     Connection(
             ConnectionCommand.class,
             null,
-            org.waarp.ftp.core.command.access.USER.class),
+            org.waarp.ftp.core.command.access.USER.class, org.waarp.ftp.core.command.rfc2389.FEAT.class),
     // XXX ACCESS CONTROL COMMAND
     /**
      * The argument field is a Telnet string identifying the user. The user identification is that


### PR DESCRIPTION
A FTP Client should be able to execute the command `FEAT` before authenticating itself,
especially to see which authentication mechanisms are supported by the server and whether
TLS/SSL is supported or not (`AUTH TLS` or `AUTL SSL` appear in `FEAT`).