### PR TITLE
MLSx responses never contaiend any facts if "OPTS MLSX" was used by the client

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,13 +19,24 @@
   <build>
   	<sourceDirectory>../src/main/java</sourceDirectory>
 
-  	<plugins>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <configuration>
+          <signature>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>java17</artifactId>
+            <version>1.0</version>
+          </signature>
+        </configuration>
+      </plugin>
   		<plugin>
   			<artifactId>maven-compiler-plugin</artifactId>
 	        <configuration>
 	          <encoding>UTF-8</encoding>
-	          <source>1.6</source>
-	          <target>1.6</target>
+	          <source>1.7</source>
+	          <target>1.7</target>
 	          <optimize>true</optimize>
 	          <showDeprecations>true</showDeprecations>
 	          <includes>

--- a/src/main/java/org/waarp/ftp/core/control/BusinessHandler.java
+++ b/src/main/java/org/waarp/ftp/core/control/BusinessHandler.java
@@ -183,21 +183,31 @@ public abstract class BusinessHandler {
      * @return the string to return to the client for the FEAT command for the MLSx argument
      */
     protected String getMLSxOptsMessage(String[] args) {
+        String[] properties = new String[0];
+        if (args.length >= 2) {
+            properties = args[1].split(";");
+        }
+
         FilesystemBasedOptsMLSxImpl optsMLSx = (FilesystemBasedOptsMLSxImpl) getFtpSession()
                 .getDir().getOptsMLSx();
         optsMLSx.setOptsModify((byte) 0);
         optsMLSx.setOptsPerm((byte) 0);
         optsMLSx.setOptsSize((byte) 0);
         optsMLSx.setOptsType((byte) 0);
-        for (int i = 1; i < args.length; i++) {
-            if (args[i].equalsIgnoreCase("modify")) {
-                optsMLSx.setOptsModify((byte) 1);
-            } else if (args[i].equalsIgnoreCase("perm")) {
-                optsMLSx.setOptsModify((byte) 1);
-            } else if (args[i].equalsIgnoreCase("size")) {
-                optsMLSx.setOptsModify((byte) 1);
-            } else if (args[i].equalsIgnoreCase("type")) {
-                optsMLSx.setOptsModify((byte) 1);
+        for (int i = 0; i < properties.length; i++) {
+            switch (properties[i].toLowerCase()) {
+                case "modify":
+                    optsMLSx.setOptsModify((byte) 1);
+                    break;
+                case "perm":
+                    optsMLSx.setOptsPerm((byte) 1);
+                    break;
+                case "size":
+                    optsMLSx.setOptsSize((byte) 1);
+                    break;
+                case "type":
+                    optsMLSx.setOptsType((byte) 1);
+                    break;
             }
         }
         return args[0] + " " + FtpCommandCode.OPTS.name() + optsMLSx.getFeat();


### PR DESCRIPTION
If the command `OPTS MLSx fact1;fact2;fact3;` was used by the client, no facts were ever returned by
MLSX functions.

There were two problems:
1. `args[1]` did not contains the list of facts (ie `{"fact1", "fact2", "fact3"}`, the complete list
   contained in the command (ie `"fact1;fact2;fact3"`). Hence the loop never got anything out of it.
2. whatever the loop did get, the only setter called was `optsMLSx.setOptsModify`, so no fact except
   modify could be set.

:warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: :warning: 
**The PR remove any compatibility with Java 1.6** because of the way the switch is written. The `pom.xml` has been edited accordingly. If this is a problem, I can edit the PR to restore compatibility 